### PR TITLE
Fix version mismatch with homeassistant

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ urls = { "Homepage" = "https://github.com/JoeyEamigh/concord4ws-py", "Bug Tracke
 [tool.poetry.dependencies]
 python = "^3.11"
 websockets = ">=12.0"
-pydantic = "1.10.17"
+pydantic = "~1.10.17"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ urls = { "Homepage" = "https://github.com/JoeyEamigh/concord4ws-py", "Bug Tracke
 
 [tool.poetry.dependencies]
 python = "^3.11"
-websockets = "^12.0"
+websockets = ">=12.0"
 pydantic = "1.10.17"
 
 [build-system]


### PR DESCRIPTION
This is the fix for the [issue I made](https://github.com/JoeyEamigh/concord4ws-ha/issues/3) on the main concord4ws repo. The issue was caused by a version mismatch between the versions of python websockets and pydantic in the repo vs what I guess is installed by home assistant itself. I am not actually sure where or why home assistant is installing those other versions, but this fixes it for me. 

Please let me know if there's anything wrong with the way I have gone about fixing this. I really like what you've built here.