### PR TITLE
Update types.py

### DIFF
--- a/concord4ws/types.py
+++ b/concord4ws/types.py
@@ -15,7 +15,7 @@ ZoneType = Literal["hardwired", "rf", "touchpad"]
 ZoneStatus = Literal[
     "normal", "tripped", "faulted", "alarm", "trouble", "bypassed", "unknown"
 ]
-PartitionArmingLevel = Literal["off", "stay", "away", "phoneTest", "sensorTest"]
+PartitionArmingLevel = Literal["off", "stay", "home", "away", "phoneTest", "sensorTest"] ##added home to match return from panel
 PanelType = Literal["concord", "concordExpress", "concordExpress4", "concordEuro"]
 ArmingLevel = Literal["zoneTest", "off", "home", "away", "night", "silent"]
 Feature = Literal[


### PR DESCRIPTION
Fix error preventing concord4ws from starting when panel armed to stay - instant, from keypad. Panel returned home, code was looking for stay? Please review as I am not familiar enough with this to know if there are other impacts, but it solved this error for me. Feel free to modify or reject as appropriate.
Error (redacted for clarity):
``
DEBUG (MainThread) [concord4ws] message received: {"type":"state","data":{"panel":{"panelType":"concord","hardwareRevision":"G1","softwareRevision":"2456","serialNumber":"1204149"},"zones":{"p1-z8":{"partitionNumber":1,"areaNumber":0,"groupNumber":13,"zoneNumber":8,"zoneType":"hardwired","zoneStatus":"normal","zoneText":"GARAGE DOOR"},"p1-z10":

Blah  Blah   Blah...

{"partitionNumber":5,"areaNumber":0,"armingLevel":"off","zones":[]},"3":{"partitionNumber":3,"areaNumber":0,"armingLevel":"off","zones":[]},"2":{"partitionNumber":2,"areaNumber":0,"armingLevel":"off","zones":[]},"1":

***Here***
{"partitionNumber":1,"areaNumber":0,"armingLevel":"home","zones":["p1-z9","p1-z2","p1-z10","p1-z3","p1-z7","p1-z1","p1-
****

z4","p1-z8","p1-z12","p1-z6","p1-z11","p1-z5"]},"4":{"partitionNumber":4,"areaNumber":0,"armingLevel":"off","zones":[]},"6":{"partitionNumber":6,"areaNumber":0,"armingLevel":"off","zones":[]}},"groups":{"p1-g17":{"partitionNumber":1,"number":17,"zones":["p1-z4","p1-z2","p1-z3"]},"p1-g12":{"partitionNumber":1,"number":12,"zones":["p1-z10","p1-z9","p1-z1"]},"p1-g16":{"partitionNumber":1,"number":16,"zones":["p1-z7","p1-z5"]},"p1-g26":{"partitionNumber":1,"number":26,"zones":["p1-z6"]},"p1-g10":{"partitionNumber":1,"number":10,"zones":["p1-z11","p1-z12"]},"p1-g13":{"partitionNumber":1,"number":13,"zones":["p1-z8"]}}}}
2025-02-02 07:23:21.961 ERROR (MainThread) [concord4ws] 1 validation error for tagged-union[StateReceivedMessage,ConcordReceivedMessage]
state.data.partitions.1.armingLevel
  Input should be 'off', 'stay', 'away', 'phoneTest' or 'sensorTest' [type=literal_error, input_value='home', input_type=str]
    For further information visit https://errors.pydantic.dev/2.10/v/literal_error
``